### PR TITLE
feat: change login signal to only include user parameter

### DIFF
--- a/openedx_events/signals/auth/v1/__init__.py
+++ b/openedx_events/signals/auth/v1/__init__.py
@@ -8,4 +8,4 @@ from django.dispatch import Signal
 REGISTER_USER = Signal(providing_args=["user", "registration"])
 
 # Signal that fires when a user logins in the platform
-LOGIN_USER = Signal(providing_args=["user", "site"])
+LOGIN_USER = Signal(providing_args=["user"])


### PR DESCRIPTION
**Description:** This changes the provided parameters of the post login signal to include the request.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed


**Author concerns:**

Still not sure if we need this, we should remove the site parameter and the consider if we need to pass the request or instead get the request with crum.get_current_request in the receivers of the signal. 
