### PR TITLE
feat: preliminary signal definition

### DIFF
--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -13,14 +13,14 @@ from openedx_events.learning.data import (
     CohortData,
     CourseEnrollmentData,
     RegistrationFormData,
-    StudentData,
+    UserData,
 )
 from openedx_events.tooling import OpenEdxPublicSignal
 
 STUDENT_REGISTRATION_COMPLETED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.student.registration.completed.v1",
     data={
-        "user": StudentData,
+        "user": UserData,
         "registration_form": RegistrationFormData,
     }
 )
@@ -29,7 +29,7 @@ STUDENT_REGISTRATION_COMPLETED = OpenEdxPublicSignal(
 SESSION_LOGIN_COMPLETED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.auth.session.login.completed.v1",
     data={
-        "user": StudentData,
+        "user": UserData,
     }
 )
 
@@ -50,7 +50,7 @@ COURSE_ENROLLMENT_CHANGED = OpenEdxPublicSignal(
 )
 
 
-COURSE_ENROLLMENT_DEACTIVATED = OpenEdxPublicSignal(
+COURSE_UNENROLLMENT_COMPLETED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.course.enrollment.deactivated.v1",
     data={
         "enrollment": CourseEnrollmentData,

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -7,3 +7,84 @@ conventions specified in docs/decisions/0002-events-naming-and-versioning.rst
 They also must comply with the payload definition specified in
 docs/decisions/0003-events-payload.rst
 """
+
+from openedx_events.learning.data import (
+    CertificateData,
+    CohortData,
+    CourseEnrollmentData,
+    RegistrationFormData,
+    StudentData,
+)
+from openedx_events.tooling import OpenEdxPublicSignal
+
+STUDENT_REGISTRATION_COMPLETED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.student.registration.completed.v1",
+    data={
+        "user": StudentData,
+        "registration_form": RegistrationFormData,
+    }
+)
+
+
+SESSION_LOGIN_COMPLETED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.auth.session.login.completed.v1",
+    data={
+        "user": StudentData,
+    }
+)
+
+
+COURSE_ENROLLMENT_CREATED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.course.enrollment.created.v1",
+    data={
+        "enrollment": CourseEnrollmentData,
+    }
+)
+
+
+COURSE_ENROLLMENT_CHANGED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.course.enrollment.changed.v1",
+    data={
+        "enrollment": CourseEnrollmentData,
+    }
+)
+
+
+COURSE_ENROLLMENT_DEACTIVATED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.course.enrollment.deactivated.v1",
+    data={
+        "enrollment": CourseEnrollmentData,
+    }
+)
+
+
+CERTIFICATE_CREATED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.certificate.created.v1",
+    data={
+        "certificate": CertificateData,
+    }
+)
+
+
+CERTIFICATE_CHANGED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.certificate.changed.v1",
+    data={
+        "certificate": CertificateData,
+    }
+)
+
+
+CERTIFICATE_REVOKED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.certificate.revoked.v1",
+    data={
+        "certificate": CertificateData,
+    }
+)
+
+
+COHORT_MEMBERSHIP_CHANGED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.cohort_membership.changed.v1",
+    data={
+        "cohort": CohortData,
+    }
+)


### PR DESCRIPTION
**Description:** 
This PR adds the first 8 definitions of the Open edX events, they will be used in the Open edX platform.

**JIRA:** Link to JIRA ticket

**Dependencies:**\
Depends on #8 

**Testing instructions:**

With the event `STUDENT_REGISTRATION_COMPLETED`:
In your Open edX devstack
1. Go to lms shell `make lms-shell`
2. Install openedx-events specifying the events definition branch:
 `pip install git+https://github.com/eduNEXT/openedx-events.git@MJG/events_definition#egg=events_definition` 
3. Change the Open edX platform branch to [MJG/post_register_event](https://github.com/eduNEXT/edx-platform/pull/221)
4. Connect your custom receiver to the signal as follows:

```
from openedx_events.learning.signals import STUDENT_REGISTRATION_COMPLETED

@receiver(STUDENT_REGISTRATION_COMPLETED)
def callback(**kwargs):
....
```
We'll add soon an example using our plugin openedx-basic-hooks!

**Reviewers:**
- [ ] @felipemontoya 
- [ ] @andrey-canon 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
