### PR TITLE
fix: fix pypi rendering error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Change Log
    This project adheres to Semantic Versioning (https://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
+
 Unreleased
 ~~~~~~~~~~
 


### PR DESCRIPTION
**Description:** 
This PR fixes the markdown error that prevented publishing the package on pypi
![2021-07-01_09-21](https://user-images.githubusercontent.com/64440265/124131844-2d76d980-da4e-11eb-864f-79fe4696e357.png)

