### PR TITLE
feat: add Medatada as data attribute

### DIFF
--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -1,0 +1,26 @@
+"""
+Data attributes for events within the architecture subdomain `learning`.
+
+These attributes follow the form of attr objects specified in OEP-49 data
+pattern.
+"""
+from datetime import datetime
+from uuid import UUID
+
+import attr
+
+
+@attr.s(frozen=True)
+class EventsMetadata:
+    """
+    Attributes defined for events metadata object.
+    """
+
+    id = attr.ib(type=UUID)
+    event_type = attr.ib(type=str)
+    minorversion = attr.ib(type=int)
+    time = attr.ib(type=datetime)
+    source = attr.ib(type=str)
+    sourcehost = attr.ib(type=str)
+    specversion = attr.ib(type=str)
+    sourcelib = attr.ib(type=str)

--- a/openedx_events/data.py
+++ b/openedx_events/data.py
@@ -4,23 +4,77 @@ Data attributes for events within the architecture subdomain `learning`.
 These attributes follow the form of attr objects specified in OEP-49 data
 pattern.
 """
+import socket
 from datetime import datetime
-from uuid import UUID
+from uuid import UUID, uuid1
 
 import attr
+from django.conf import settings
+
+import openedx_events
 
 
 @attr.s(frozen=True)
 class EventsMetadata:
     """
-    Attributes defined for events metadata object.
+    Attributes defined for Open edX Events metadata object.
+
+    The attributes defined in this class are a subset of the
+    OEP-41: Asynchronous Server Event Message Format.
+
+    Arguments:
+        id (UUID): event identifier.
+        event_type (str): name of the event.
+        minorversion (int): version of the event type.
+        source (str): logical source of an event.
+        sourcehost (str): physical source of the event.
+        time (datetime): timestamp when the event was sent.
+        sourcelib (str): Open edX Events library version.
     """
 
-    id = attr.ib(type=UUID)
+    id = attr.ib(
+        type=UUID,
+        init=False,
+    )
     event_type = attr.ib(type=str)
-    minorversion = attr.ib(type=int)
-    time = attr.ib(type=datetime)
-    source = attr.ib(type=str)
-    sourcehost = attr.ib(type=str)
-    specversion = attr.ib(type=str)
-    sourcelib = attr.ib(type=str)
+    minorversion = attr.ib(
+        type=int,
+        converter=attr.converters.default_if_none(0),
+    )
+    source = attr.ib(
+        type=str,
+        init=False,
+    )
+    sourcehost = attr.ib(
+        type=str,
+        init=False,
+    )
+    time = attr.ib(
+        type=datetime,
+        init=False,
+    )
+    sourcelib = attr.ib(
+        type=tuple,
+        init=False,
+    )
+
+    def __attrs_post_init__(self):
+        """
+        Post-init hook that generates metadata for the Open edX Event.
+        """
+        # Have to use this to get around the fact that the class is frozen
+        # (which we almost always want, but not while we're initializing it).
+        # Taken from edX Learning Sequences data file.
+        object.__setattr__(self, "id", uuid1())
+        object.__setattr__(
+            self,
+            "source",
+            "openedx/{service}/web".format(
+                service=getattr(settings, "SERVICE_VARIANT", "")
+            ),
+        )
+        object.__setattr__(self, "sourcehost", socket.gethostname())
+        object.__setattr__(self, "time", datetime.utcnow())
+        object.__setattr__(
+            self, "sourcelib", tuple(map(int, openedx_events.__version__.split(".")))
+        )

--- a/openedx_events/exceptions.py
+++ b/openedx_events/exceptions.py
@@ -1,0 +1,69 @@
+"""
+Custom exceptions thrown by Open edX events tooling.
+"""
+
+
+class OpenEdxEventException(Exception):
+    """
+    Base class for Open edX Events exceptions.
+    """
+
+    def __init__(self, message=""):
+        """
+        Init method for OpenEdxEventException base class.
+
+        Arguments:
+            message (str): message describing why the exception was raised.
+        """
+        super().__init__()
+        self.message = message
+
+    def __str__(self):
+        """
+        Show string representation of OpenEdxEventException using its message.
+        """
+        return self.message
+
+
+class InstantiationError(OpenEdxEventException):
+    """
+    Describes errors that occur while instantiating events.
+
+    This exception is raised when there's an error instantiating an Open edX
+    event, it can be that a required argument for the event definition is
+    missing.
+    """
+
+    def __init__(self, event_type="", message=""):
+        """
+        Init method for InstantiationError custom exception class.
+
+        Arguments:
+            event_type (str): name of the event raising the exception.
+            message (str): message describing why the exception was raised.
+        """
+        super().__init__(
+            message="InstantiationError {event_type}: {message}".format(
+                event_type=event_type, message=message
+            )
+        )
+
+
+class SenderValidationError(OpenEdxEventException):
+    """
+    Describes errors that occur while validating arguments of send methods.
+    """
+
+    def __init__(self, event_type="", message=""):
+        """
+        Init method for SenderValidationError custom exception class.
+
+        Arguments:
+            event_type (str): name of the event raising the exception.
+            message (str): message describing why the exception was raised.
+        """
+        super().__init__(
+            message="SenderValidationError {event_type}: {message}".format(
+                event_type=event_type, message=message
+            )
+        )

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -14,6 +14,10 @@ from opaque_keys.edx.keys import CourseKey
 class UserNonPersonalData:
     """
     Attributes defined for Open edX user object based on non-PII data.
+
+    Arguments:
+        id (int): unique identifier for the Django User object.
+        is_active (bool): indicates whether the user is active.
     """
 
     id = attr.ib(type=int)
@@ -24,6 +28,11 @@ class UserNonPersonalData:
 class UserPersonalData:
     """
     Attributes defined for Open edX user object based on PII data.
+
+    Arguments:
+        username (str): username associated with the Open edX user.
+        email (str): email associated with the Open edX user.
+        name (str): email associated with the Open edX user's profile.
     """
 
     username = attr.ib(type=str)
@@ -35,6 +44,12 @@ class UserPersonalData:
 class UserData:
     """
     Attributes defined for Open edX user object.
+
+    Arguments:
+        user_non_pii (UserNonPersonalData): user's Personal Identifiable
+        Information.
+        user_pii (UserPersonalData): user's Non Personal Identifiable
+        Information.
     """
 
     user_non_pii = attr.ib(type=UserNonPersonalData)
@@ -45,6 +60,12 @@ class UserData:
 class CourseData:
     """
     Attributes defined for Open edX Course Overview object.
+
+    Arguments:
+        course_key (str): identifier of the Course object.
+        display_name (str): display name associated with the course.
+        start (datetime): start date for the course.
+        end (datetime): end date for the course.
     """
 
     course_key = attr.ib(type=CourseKey)
@@ -57,6 +78,14 @@ class CourseData:
 class CourseEnrollmentData:
     """
     Attributes defined for Open edX Course Enrollment object.
+
+    Arguments:
+        user (UserData): user associated with the Course Enrollment.
+        course (CourseData): course where the user is enrolled in.
+        mode (str): course mode associated with the course.
+        is_active (bool): whether the enrollment is active.
+        creation_date (datetime): creation date of the enrollment.
+        created_by (UserData): if available, who created the enrollment.
     """
 
     user = attr.ib(type=UserData)
@@ -71,21 +100,37 @@ class CourseEnrollmentData:
 class CertificateData:
     """
     Attributes defined for Open edX Certificate data object.
+
+    Arguments:
+        user (UserData): user associated with the Certificate.
+        course (CourseData): course where the user obtained the certificate.
+        mode (str): course mode associated with the course.
+        grade (str): user's grade in this course run.
+        current_status (str): current certificate status.
+        previous_status (str): if available, pre-event certificate status.
+        download_url (str): URL where the PDF version of the certificate.
+        name (str): user's name.
     """
 
     user = attr.ib(type=UserData)
     course = attr.ib(type=CourseData)
     mode = attr.ib(type=str)
     grade = attr.ib(type=str)
-    status = attr.ib(type=str)
     download_url = attr.ib(type=str)
     name = attr.ib(type=str)
+    current_status = attr.ib(type=str)
+    previous_status = attr.ib(type=str, factory=str)
 
 
 @attr.s(frozen=True)
 class CohortData:
     """
     Attributes defined for Open edX Cohort Membership object.
+
+    Arguments:
+        user (UserData): user assigned to the group.
+        course (CourseData): course associated with the course group.
+        name (str): name of the cohort group.
     """
 
     user = attr.ib(type=UserData)

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -14,14 +14,32 @@ from opaque_keys.edx.keys import CourseKey
 @attr.s(frozen=True)
 class StudentData:
     """
-    Attributes defined for Open edX student object.
+    Attributes defined for Open edX user object based on non-PII data.
+    """
+
+    id = attr.ib(type=int)
+    is_active = attr.ib(type=bool, default=True)
+
+
+@attr.s(frozen=True)
+class UserPersonalData:
+    """
+    Attributes defined for Open edX user object based on PII data.
     """
 
     username = attr.ib(type=str)
     email = attr.ib(type=str)
-    is_active = attr.ib(type=bool, default=True)
-    meta = attr.ib(type=Dict[str, str], factory=dict)
     name = attr.ib(type=str, factory=str)
+
+
+@attr.s(frozen=True)
+class UserData:
+    """
+    Attributes defined for Open edX user object.
+    """
+
+    student = attr.ib(type=StudentData)
+    user = attr.ib(type=UserPersonalData)
 
 
 @attr.s(frozen=True)
@@ -52,7 +70,7 @@ class CourseEnrollmentData:
     Attributes defined for Open edX Course Enrollment object.
     """
 
-    user = attr.ib(type=StudentData)
+    user = attr.ib(type=UserData)
     course = attr.ib(type=CourseData)
     mode = attr.ib(type=str)
     is_active = attr.ib(type=bool)
@@ -64,7 +82,7 @@ class CertificateData:
     Attributes defined for Open edX Certificate data object.
     """
 
-    user = attr.ib(type=StudentData)
+    user = attr.ib(type=UserData)
     course = attr.ib(type=CourseData)
     mode = attr.ib(type=str)
     grade = attr.ib(type=str)
@@ -79,6 +97,6 @@ class CohortData:
     Attributes defined for Open edX Cohort Membership object.
     """
 
-    user = attr.ib(type=StudentData)
+    user = attr.ib(type=UserData)
     course = attr.ib(type=CourseData)
     name = attr.ib(type=str)

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -1,0 +1,84 @@
+"""
+Data attributes for events within the architecture subdomain `learning`.
+
+These attributes follow the form of attr objects specified in OEP-49 data
+pattern.
+"""
+from datetime import datetime
+from typing import Dict
+
+import attr
+from opaque_keys.edx.keys import CourseKey
+
+
+@attr.s(frozen=True)
+class StudentData:
+    """
+    Attributes defined for Open edX student object.
+    """
+
+    username = attr.ib(type=str)
+    email = attr.ib(type=str)
+    is_active = attr.ib(type=bool, default=True)
+    meta = attr.ib(type=Dict[str, str], factory=dict)
+    name = attr.ib(type=str, factory=str)
+
+
+@attr.s(frozen=True)
+class RegistrationFormData:
+    """
+    Attributes defined for Open edX student object.
+    """
+
+    account_form = attr.ib(type=Dict[str, str], factory=dict)
+    extension_form = attr.ib(type=Dict[str, str], factory=dict)
+
+
+@attr.s(frozen=True)
+class CourseData:
+    """
+    Attributes defined for Open edX Course Overview object.
+    """
+
+    course_key = attr.ib(type=CourseKey)
+    display_name = attr.ib(type=str, factory=str)
+    start = attr.ib(type=datetime, default=None)
+    end = attr.ib(type=datetime, default=None)
+
+
+@attr.s(frozen=True)
+class CourseEnrollmentData:
+    """
+    Attributes defined for Open edX Course Enrollment object.
+    """
+
+    user = attr.ib(type=StudentData)
+    course = attr.ib(type=CourseData)
+    mode = attr.ib(type=str)
+    is_active = attr.ib(type=bool)
+
+
+@attr.s(frozen=True)
+class CertificateData:
+    """
+    Attributes defined for Open edX Certificate data object.
+    """
+
+    user = attr.ib(type=StudentData)
+    course = attr.ib(type=CourseData)
+    mode = attr.ib(type=str)
+    grade = attr.ib(type=str)
+    status = attr.ib(type=str)
+    download_url = attr.ib(type=str)
+    name = attr.ib(type=str)
+
+
+@attr.s(frozen=True)
+class CohortData:
+    """
+    Attributes defined for Open edX Cohort Membership object.
+    """
+
+    user = attr.ib(type=StudentData)
+    course = attr.ib(type=CourseData)
+    name = attr.ib(type=str)

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -43,16 +43,6 @@ class UserData:
 
 
 @attr.s(frozen=True)
-class RegistrationFormData:
-    """
-    Attributes defined for Open edX student object.
-    """
-
-    account_form = attr.ib(type=Dict[str, str], factory=dict)
-    extension_form = attr.ib(type=Dict[str, str], factory=dict)
-
-
-@attr.s(frozen=True)
 class CourseData:
     """
     Attributes defined for Open edX Course Overview object.
@@ -70,12 +60,12 @@ class CourseEnrollmentData:
     Attributes defined for Open edX Course Enrollment object.
     """
 
-    creation_date = attr.ib(type=datetime)
-    created_by = attr.ib(type=UserData)
     user = attr.ib(type=UserData)
     course = attr.ib(type=CourseData)
     mode = attr.ib(type=str)
     is_active = attr.ib(type=bool)
+    creation_date = attr.ib(type=datetime)
+    created_by = attr.ib(type=UserData, default=None)
 
 
 @attr.s(frozen=True)

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -12,7 +12,7 @@ from opaque_keys.edx.keys import CourseKey
 
 
 @attr.s(frozen=True)
-class StudentData:
+class UserNonPersonalData:
     """
     Attributes defined for Open edX user object based on non-PII data.
     """
@@ -38,7 +38,7 @@ class UserData:
     Attributes defined for Open edX user object.
     """
 
-    student = attr.ib(type=StudentData)
+    user_non_pii = attr.ib(type=UserNonPersonalData)
     user = attr.ib(type=UserPersonalData)
 
 
@@ -70,6 +70,8 @@ class CourseEnrollmentData:
     Attributes defined for Open edX Course Enrollment object.
     """
 
+    creation_date = attr.ib(type=datetime)
+    created_by = attr.ib(type=UserData)
     user = attr.ib(type=UserData)
     course = attr.ib(type=CourseData)
     mode = attr.ib(type=str)

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -5,7 +5,6 @@ These attributes follow the form of attr objects specified in OEP-49 data
 pattern.
 """
 from datetime import datetime
-from typing import Dict
 
 import attr
 from opaque_keys.edx.keys import CourseKey
@@ -39,7 +38,7 @@ class UserData:
     """
 
     user_non_pii = attr.ib(type=UserNonPersonalData)
-    user = attr.ib(type=UserPersonalData)
+    user_pii = attr.ib(type=UserPersonalData)
 
 
 @attr.s(frozen=True)

--- a/openedx_events/tests/test_tooling.py
+++ b/openedx_events/tests/test_tooling.py
@@ -4,8 +4,8 @@ Classes:
     EventsToolingTest: Test events tooling.
 """
 from unittest.mock import Mock, patch
-import attr
 
+import attr
 import ddt
 from django.test import TestCase, override_settings
 
@@ -44,8 +44,8 @@ class OpenEdxPublicSignalTest(TestCase):
         self.assertIn(self.event_type, str(self.public_signal))
 
     @override_settings(SERVICE_VARIANT="lms")
-    @patch("openedx_events.tooling.openedx_events")
-    @patch("openedx_events.tooling.socket")
+    @patch("openedx_events.data.openedx_events")
+    @patch("openedx_events.data.socket")
     def test_get_signal_metadata(self, socket_mock, events_package_mock):
         """
         This methods tests getting the generated metadata for an event.
@@ -60,7 +60,7 @@ class OpenEdxPublicSignalTest(TestCase):
             "minorversion": 0,
             "source": "openedx/lms/web",
             "sourcehost": "edx.devstack.lms",
-            "sourcelib": (0, 1, 0),
+            "sourcelib": [0, 1, 0],
         }
 
         metadata = self.public_signal.generate_signal_metadata()

--- a/openedx_events/tests/test_tooling.py
+++ b/openedx_events/tests/test_tooling.py
@@ -4,6 +4,7 @@ Classes:
     EventsToolingTest: Test events tooling.
 """
 from unittest.mock import Mock, patch
+import attr
 
 import ddt
 from django.test import TestCase, override_settings
@@ -64,7 +65,7 @@ class OpenEdxPublicSignalTest(TestCase):
 
         metadata = self.public_signal.generate_signal_metadata()
 
-        self.assertDictContainsSubset(expected_metadata, metadata)
+        self.assertDictContainsSubset(expected_metadata, attr.asdict(metadata))
 
     @ddt.data(
         ("", {"user": Mock()}, "event_type"),

--- a/openedx_events/tests/test_tooling.py
+++ b/openedx_events/tests/test_tooling.py
@@ -1,0 +1,216 @@
+"""This file contains all test for the tooling.py file.
+
+Classes:
+    EventsToolingTest: Test events tooling.
+"""
+from unittest.mock import Mock, patch
+
+import ddt
+from django.test import TestCase, override_settings
+
+from openedx_events.exceptions import InstantiationError, SenderValidationError
+from openedx_events.tooling import OpenEdxPublicSignal
+
+
+@ddt.ddt
+class OpenEdxPublicSignalTest(TestCase):
+    """
+    Test cases for Open edX events base class.
+    """
+
+    def setUp(self):
+        """
+        Setup common conditions for every test case.
+        """
+        super().setUp()
+        self.event_type = "org.openedx.learning.session.login.completed.v1"
+        self.user_mock = Mock()
+        self.data_attr = {
+            "user": Mock,
+        }
+        self.public_signal = OpenEdxPublicSignal(
+            event_type=self.event_type, data=self.data_attr,
+        )
+
+    def test_string_representation(self):
+        """
+        This methods checks the string representation for events base class.
+
+        Expected behavior:
+            The representation contains the event_type.
+        """
+        self.assertIn(self.event_type, str(self.public_signal))
+
+    @override_settings(SERVICE_VARIANT="lms")
+    @patch("openedx_events.tooling.openedx_events")
+    @patch("openedx_events.tooling.crum")
+    def test_get_signal_metadata(self, crum_mock, events_package_mock):
+        """
+        This methods tests getting the generated metadata for an event.
+
+        Expected behavior:
+            Returns the metadata containing information about the event.
+        """
+        events_package_mock.__version__ = "0.1.0"
+        crum_mock.get_current_request.return_value.get_host.return_value = "edx.devstack.lms"
+        expected_metadata = {
+            "event_type": self.event_type,
+            "minorversion": "0.0",
+            "source": "openedx/lms/web",
+            "sourcehost": "edx.devstack.lms",
+            "specversion": "1.0",
+            "events_version": "0.1.0",
+        }
+
+        metadata = self.public_signal.get_signal_metadata()
+
+        self.assertDictContainsSubset(expected_metadata, metadata)
+
+    @override_settings(SERVICE_VARIANT="lms")
+    @patch("openedx_events.tooling.openedx_events")
+    def test_get_signal_metadata_unknown_host(self, events_package_mock):
+        """
+        This methods tests getting the generated metadata without a host.
+
+        Expected behavior:
+            Returns the metadata containing information about the event.
+        """
+        events_package_mock.__version__ = "0.1.0"
+        expected_metadata = {
+            "event_type": self.event_type,
+            "minorversion": "0.0",
+            "source": "openedx/lms/web",
+            "sourcehost": "Unknown host",
+            "specversion": "1.0",
+            "events_version": "0.1.0",
+        }
+
+        metadata = self.public_signal.get_signal_metadata()
+
+        self.assertDictContainsSubset(expected_metadata, metadata)
+
+    @ddt.data(
+        ("", {"user": Mock()}, "event_type"),
+        ("org.openedx.learning.session.login.completed.v1", None, "data"),
+    )
+    @ddt.unpack
+    def test_event_instantiation_exception(
+        self, event_type, event_data, missing_argument
+    ):
+        """
+        This method tests when an event is instantiated without event_type or
+        event data.
+
+        Expected behavior:
+            An InstantiationError exception is raised.
+        """
+        exception_message = "InstantiationError {event_type}: Missing required argument '{missing_argument}'".format(
+            event_type=event_type,
+            missing_argument=missing_argument
+        )
+
+        with self.assertRaisesMessage(InstantiationError, exception_message):
+            OpenEdxPublicSignal(event_type=event_type, data=event_data)
+
+    @patch("openedx_events.tooling.OpenEdxPublicSignal.get_signal_metadata")
+    @patch("openedx_events.tooling.Signal.send")
+    def test_send_event_successfully(self, send_mock, fake_metadata):
+        """
+        This method tests the process of sending an event.
+
+        Expected behavior:
+            The event is sent as a django signal.
+        """
+        expected_metadata = {
+            "some_data": "data",
+            "raise_exception": True,
+        }
+        fake_metadata.return_value = expected_metadata
+
+        self.public_signal.send_event(user=self.user_mock)
+
+        send_mock.assert_called_once_with(
+            sender=None,
+            user=self.user_mock,
+            metadata=expected_metadata,
+        )
+
+    @patch("openedx_events.tooling.OpenEdxPublicSignal.get_signal_metadata")
+    @patch("openedx_events.tooling.Signal.send_robust")
+    def test_send_robust_event_successfully(self, send_robust_mock, fake_metadata):
+        """
+        This method tests the process of sending an event.
+
+        Expected behavior:
+            The event is sent as a django signal.
+        """
+        expected_metadata = {
+            "some_data": "data",
+            "raise_exception": True,
+        }
+        fake_metadata.return_value = expected_metadata
+
+        self.public_signal.send_event(user=self.user_mock, send_robust=True)
+
+        send_robust_mock.assert_called_once_with(
+            sender=None,
+            user=self.user_mock,
+            metadata=expected_metadata,
+        )
+
+    @ddt.data(
+        (
+            {"student": Mock()},
+            "SenderValidationError org.openedx.learning.session.login.completed.v1: "
+            "Missing required argument 'user'",
+        ),
+        (
+            {"user": {"student": Mock()}},
+            "SenderValidationError org.openedx.learning.session.login.completed.v1: "
+            "The argument 'user' is not instance of the Class Attribute 'type'",
+        ),
+        (
+            {"student": Mock(), "user": Mock()},
+            "SenderValidationError org.openedx.learning.session.login.completed.v1: "
+            "There's a mismatch between initialization data and send_event arguments",
+        ),
+    )
+    @ddt.unpack
+    def test_invalid_sender(self, send_arguments, exception_message):
+        """
+        This method tests sending an event with invalid setup on the sender
+        side.
+
+        Expected behavior:
+            A SenderValidationError exception is raised.
+        """
+        with self.assertRaisesMessage(SenderValidationError, exception_message):
+            self.public_signal.send_event(**send_arguments)
+
+    def test_send_event_with_django(self):
+        """
+        This method tests sending an event using the `send` built-in Django
+        method.
+
+        Expected behavior:
+            A warning is showed advicing to use Open edX events custom
+            send_signal method.
+        """
+        message = "Please, use 'send_event' when triggering an Open edX event."
+
+        with self.assertWarns(Warning, msg=message):
+            self.public_signal.send(sender=Mock())
+
+    def test_send_robust_event_with_django(self):
+        """
+        This method tests sending an event using the `send` built-in Django
+        method.
+
+        Expected behavior:
+            A warning is showed advicing to use Open edX events custom
+            send_signal method.
+        """
+        message = "Please, use 'send_event' with send_robust equals to True when triggering an Open edX event."
+
+        with self.assertWarns(Warning, msg=message):
+            self.public_signal.send_robust(sender=Mock())

--- a/openedx_events/tests/test_tooling.py
+++ b/openedx_events/tests/test_tooling.py
@@ -29,7 +29,8 @@ class OpenEdxPublicSignalTest(TestCase):
             "user": Mock,
         }
         self.public_signal = OpenEdxPublicSignal(
-            event_type=self.event_type, data=self.data_attr,
+            event_type=self.event_type,
+            data=self.data_attr,
         )
 
     def test_string_representation(self):
@@ -58,8 +59,7 @@ class OpenEdxPublicSignalTest(TestCase):
             "minorversion": 0,
             "source": "openedx/lms/web",
             "sourcehost": "edx.devstack.lms",
-            "specversion": "1.0",
-            "sourcelib": "0.1.0",
+            "sourcelib": (0, 1, 0),
         }
 
         metadata = self.public_signal.generate_signal_metadata()
@@ -82,8 +82,7 @@ class OpenEdxPublicSignalTest(TestCase):
             An InstantiationError exception is raised.
         """
         exception_message = "InstantiationError {event_type}: Missing required argument '{missing_argument}'".format(
-            event_type=event_type,
-            missing_argument=missing_argument
+            event_type=event_type, missing_argument=missing_argument
         )
 
         with self.assertRaisesMessage(InstantiationError, exception_message):

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -1,0 +1,199 @@
+"""
+Tooling necessary to use Open edX events.
+"""
+import warnings
+from datetime import datetime
+
+from django.conf import settings
+from django.dispatch import Signal
+
+import openedx_events
+from openedx_events.exceptions import InstantiationError, SenderValidationError
+
+try:
+    import crum
+except ImportError:
+    crum = None
+
+
+class OpenEdxPublicSignal(Signal):
+    """
+    Custom class used to create Open edX events.
+    """
+
+    def __init__(self, event_type, data, minor_version="0.0"):
+        """
+        Init method for OpenEdxPublicSignal definition class.
+
+        Arguments:
+            event_type (str): name of the event.
+            data (dict): attributes passed to the event.
+            minor_version (str): version of the event type.
+        """
+        if not event_type:
+            raise InstantiationError(
+                message="Missing required argument 'event_type'"
+            )
+        if not data:
+            raise InstantiationError(
+                event_type=event_type, message="Missing required argument 'data'"
+            )
+        self.init_data = data
+        self.event_type = event_type
+        self.minor_version = minor_version
+        super().__init__()
+
+    def __repr__(self):
+        """
+        Represent OpenEdxPublicSignal as a string.
+        """
+        return "<OpenEdxPublicSignal: {event_type}>".format(event_type=self.event_type)
+
+    def get_signal_metadata(self):
+        """
+        Get signal extra metadata when an event is sent.
+
+        These fields are generated on the fly and are a subset of the Event
+        Message defined in the OEP-41.
+
+        Example usage:
+            >>> STUDENT_REGISTRATION_COMPLETED.get_signal_metadata()
+            {
+                'event_type': '...learning.student.registration.completed.v1',
+                'minorversion': '0.0',
+                'time': '2021-06-09T14:12:45.320819Z',
+                'source': 'openedx/lms/web',
+                'sourcehost': 'edx.devstack.lms',
+                'specversion': '1.0',
+                'events_version: '0.1.0',
+            }
+        """
+
+        def get_current_time():
+            """
+            Getter function used to get timestamp when the event ocurred.
+            """
+            return datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        def get_source():
+            """
+            Getter function used to get logical source of an event.
+            """
+            return "openedx/{service}/web".format(
+                service=getattr(settings, "SERVICE_VARIANT", "")
+            )
+
+        def get_source_host():
+            """
+            Getter function used to get physical source of the event.
+            """
+            if not crum:
+                return 'Unknown host'
+            current_request = crum.get_current_request()
+            return current_request.get_host() if current_request else None
+
+        def get_spec_version():
+            """
+            Getter function used to get the version of CloudEvents.
+
+            This field is added to be compliant with OEP-41, it's not
+            necessarily significant to the Open edX events metadata.
+            """
+            return "1.0"
+
+        def get_events_version():
+            """
+            Getter function used to get the Open edX Events version.
+            """
+            return openedx_events.__version__
+
+        return {
+            "event_type": self.event_type,
+            "minorversion": self.minor_version,
+            "time": get_current_time(),
+            "source": get_source(),
+            "sourcehost": get_source_host(),
+            "specversion": get_spec_version(),
+            "events_version": get_events_version(),
+        }
+
+    def send_event(self, send_robust=False, **kwargs):
+        """
+        Send events to all connected receivers.
+
+        Used to send events just like Django signals are sent. In addition,
+        some validations are run on the arguments, and then relevant metadata
+        that can be used for logging or debugging purposes is generated.
+        Besides this behavior, send_event behaves just like the send method.
+
+        Example usage:
+            >>> STUDENT_REGISTRATION_COMPLETED.send_event(
+                user=user_data, registration=registration_data,
+            )
+            [(<function callback at 0x7f2ce638ef70>, 'callback response')]
+
+        Keyword arguments:
+            send_robust (bool): determines whether the Django signal will be
+            sent using the method `send` or `send_robust`.
+
+        Returns:
+            list: response of each receiver following the format
+            [(receiver, response), ... ]
+
+        Exceptions raised:
+            SenderValidationError: raised when there's a mismatch between
+            arguments passed to this method and arguments used to initialize
+            the event.
+        """
+
+        def validate_sender():
+            """
+            Run validations over the send arguments.
+
+            The validation checks whether the send arguments match the
+            arguments used when instantiating the event. If they don't a
+            validation error is raised.
+            """
+            if len(kwargs) != len(self.init_data):
+                raise SenderValidationError(
+                    event_type=self.event_type,
+                    message="There's a mismatch between initialization data and send_event arguments",
+                )
+
+            for key, value in self.init_data.items():
+                argument = kwargs.get(key)
+                if not argument:
+                    raise SenderValidationError(
+                        event_type=self.event_type,
+                        message="Missing required argument '{key}'".format(key=key),
+                    )
+                if not isinstance(argument, value):
+                    raise SenderValidationError(
+                        event_type=self.event_type,
+                        message="The argument '{key}' is not instance of the Class Attribute '{attr}'".format(
+                            key=key, attr=value.__class__.__name__
+                        ),
+                    )
+
+        validate_sender()
+
+        kwargs["metadata"] = self.get_signal_metadata()
+        kwargs["metadata"]["raise_exception"] = not send_robust
+
+        if send_robust:
+            return super().send_robust(sender=None, **kwargs)
+        return super().send(sender=None, **kwargs)
+
+    def send(self, sender, **kwargs):  # pylint: disable=unused-argument
+        """
+        Override method used to recommend the sender to adopt our custom send.
+        """
+        warnings.warn("Please, use 'send_event' when triggering an Open edX event.")
+
+    def send_robust(self, sender, **kwargs):  # pylint: disable=unused-argument
+        """
+        Override method used to recommend the sender to adopt our custom send.
+        """
+        warnings.warn(
+            "Please, use 'send_event' with send_robust equals to True when triggering an Open edX event."
+        )

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.dispatch import Signal
 
 import openedx_events
+from openedx_events.data import EventsMetadata
 from openedx_events.exceptions import InstantiationError, SenderValidationError
 
 
@@ -97,15 +98,15 @@ class OpenEdxPublicSignal(Signal):
             """
             return tuple(map(int, openedx_events.__version__.split(".")))
 
-        return {
-            "id": generate_uuid(),
-            "event_type": self.event_type,
-            "minorversion": self.minor_version,
-            "time": get_current_time(),
-            "source": get_source(),
-            "sourcehost": get_source_host(),
-            "sourcelib": get_source_lib(),
-        }
+        return EventsMetadata(
+            id=generate_uuid(),
+            event_type=self.event_type,
+            minorversion=self.minor_version,
+            time=get_current_time(),
+            source=get_source(),
+            sourcehost=get_source_host(),
+            sourcelib=get_source_lib(),
+        )
 
     def send_event(self, send_robust=False, **kwargs):
         """

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -1,15 +1,10 @@
 """
 Tooling necessary to use Open edX events.
 """
-import socket
 import warnings
-from datetime import datetime
-from uuid import uuid1
 
-from django.conf import settings
 from django.dispatch import Signal
 
-import openedx_events
 from openedx_events.data import EventsMetadata
 from openedx_events.exceptions import InstantiationError, SenderValidationError
 
@@ -55,7 +50,9 @@ class OpenEdxPublicSignal(Signal):
         Message defined in the OEP-41.
 
         Example usage:
-            >>> STUDENT_REGISTRATION_COMPLETED.generate_signal_metadata()
+            >>> metadata = \
+                STUDENT_REGISTRATION_COMPLETED.generate_signal_metadata()
+                attr.asdict(metadata)
             {
                 'event_type': '...learning.student.registration.completed.v1',
                 'minorversion': 0,
@@ -66,46 +63,9 @@ class OpenEdxPublicSignal(Signal):
                 'sourcelib: (0,1,0,),
             }
         """
-        def generate_uuid():
-            """
-            Generate events id based on UUID version 1.
-            """
-            return uuid1()
-
-        def get_current_time():
-            """
-            Get timestamp when the event was sent.
-            """
-            return datetime.utcnow()
-
-        def get_source():
-            """
-            Get logical source of an event.
-            """
-            return "openedx/{service}/web".format(
-                service=getattr(settings, "SERVICE_VARIANT", "")
-            )
-
-        def get_source_host():
-            """
-            Get physical source of the event.
-            """
-            return socket.gethostname()
-
-        def get_source_lib():
-            """
-            Getter function used to obtain Open edX Events version.
-            """
-            return tuple(map(int, openedx_events.__version__.split(".")))
-
         return EventsMetadata(
-            id=generate_uuid(),
             event_type=self.event_type,
             minorversion=self.minor_version,
-            time=get_current_time(),
-            source=get_source(),
-            sourcehost=get_source_host(),
-            sourcelib=get_source_lib(),
         )
 
     def send_event(self, send_robust=False, **kwargs):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,6 @@
 # Core requirements for using this application
 -c constraints.txt
 
+attrs
 django
+edx-opaque-keys[django]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,11 +4,21 @@
 #
 #    make upgrade
 #
+attrs==21.2.0
+    # via -r requirements/base.in
 django==2.2.24
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
+edx-opaque-keys[django]==2.2.2
+    # via -r requirements/base.in
+pbr==5.6.0
+    # via stevedore
+pymongo==3.11.4
+    # via edx-opaque-keys
 pytz==2021.1
     # via django
 sqlparse==0.4.1
     # via django
+stevedore==3.3.0
+    # via edx-opaque-keys

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -68,6 +68,8 @@ cryptography==3.4.7
     # via
     #   -r requirements/quality.txt
     #   secretstorage
+ddt==1.4.2
+    # via -r requirements/quality.txt
 diff-cover==6.0.0
     # via -r requirements/dev.in
 distlib==0.3.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -87,6 +87,8 @@ docutils==0.17.1
     #   readme-renderer
 edx-lint==5.0.0
     # via -r requirements/quality.txt
+edx-opaque-keys[django]==2.2.2
+    # via -r requirements/quality.txt
 filelock==3.0.12
     # via
     #   -r requirements/ci.txt
@@ -208,6 +210,10 @@ pylint-plugin-utils==0.6
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
+pymongo==3.11.4
+    # via
+    #   -r requirements/quality.txt
+    #   edx-opaque-keys
 pyparsing==2.4.7
     # via
     #   -r requirements/ci.txt
@@ -278,6 +284,7 @@ stevedore==3.3.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
+    #   edx-opaque-keys
 text-unidecode==1.3
     # via
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -44,6 +44,8 @@ docutils==0.17.1
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
+edx-opaque-keys[django]==2.2.2
+    # via -r requirements/test.txt
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
 idna==2.10
@@ -86,6 +88,10 @@ pygments==2.9.0
     #   doc8
     #   readme-renderer
     #   sphinx
+pymongo==3.11.4
+    # via
+    #   -r requirements/test.txt
+    #   edx-opaque-keys
 pyparsing==2.4.7
     # via
     #   -r requirements/test.txt
@@ -151,6 +157,7 @@ stevedore==3.3.0
     #   -r requirements/test.txt
     #   code-annotations
     #   doc8
+    #   edx-opaque-keys
 text-unidecode==1.3
     # via
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -34,6 +34,8 @@ django==2.2.24
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
+ddt==1.4.2
+    # via -r requirements/test.txt
 doc8==0.8.1
     # via -r requirements/doc.in
 docutils==0.17.1

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -51,6 +51,8 @@ docutils==0.17.1
     # via readme-renderer
 edx-lint==5.0.0
     # via -r requirements/quality.in
+edx-opaque-keys[django]==2.2.2
+    # via -r requirements/test.txt
 idna==2.10
     # via requests
 importlib-metadata==4.6.1
@@ -124,6 +126,10 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
+pymongo==3.11.4
+    # via
+    #   -r requirements/test.txt
+    #   edx-opaque-keys
 pyparsing==2.4.7
     # via
     #   -r requirements/test.txt
@@ -176,6 +182,7 @@ stevedore==3.3.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   edx-opaque-keys
 text-unidecode==1.3
     # via
     #   -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -40,6 +40,8 @@ coverage==5.5
     #   pytest-cov
 cryptography==3.4.7
     # via secretstorage
+ddt==1.4.2
+    # via -r requirements/test.txt
 django==2.2.24
     # via
     #   -c requirements/constraints.txt

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,6 +3,7 @@
 
 -r base.txt               # Core dependencies for this package
 
+ddt                       # A library to multiply test cases
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 code-annotations          # provides commands used by the pii_check make target.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,9 @@
 #    make upgrade
 #
 attrs==21.2.0
-    # via pytest
+    # via
+    #   -r requirements/base.txt
+    #   pytest
 click==8.0.1
     # via code-annotations
 code-annotations==1.1.2
@@ -18,6 +20,8 @@ django==2.2.24
     #   -r requirements/base.txt
 ddt==1.4.2
     # via -r requirements/test.in
+edx-opaque-keys[django]==2.2.2
+    # via -r requirements/base.txt
 iniconfig==1.1.1
     # via pytest
 jinja2==3.0.1
@@ -27,11 +31,17 @@ markupsafe==2.0.1
 packaging==21.0
     # via pytest
 pbr==5.6.0
-    # via stevedore
+    # via
+    #   -r requirements/base.txt
+    #   stevedore
 pluggy==0.13.1
     # via pytest
 py==1.10.0
     # via pytest
+pymongo==3.11.4
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
 pyparsing==2.4.7
     # via packaging
 pytest==6.2.4
@@ -55,7 +65,10 @@ sqlparse==0.4.1
     #   -r requirements/base.txt
     #   django
 stevedore==3.3.0
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
 toml==0.10.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,6 +16,8 @@ django==2.2.24
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
+ddt==1.4.2
+    # via -r requirements/test.in
 iniconfig==1.1.1
     # via pytest
 jinja2==3.0.1


### PR DESCRIPTION
**Description:** 

This PR modifies the metadata object sent when triggering an Open edX event. 

**JIRA:** Link to JIRA ticket

**Dependencies:** 
This PR depends on #8 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**
1. Install openedx-events using the current branch
2. Go to Django shell:
```
>>> from openedx_events.tooling import OpenEdxPublicSignal
>>> public_signal = OpenEdxPublicSignal(event_type="org.openedx.learning.session.login.completed.v1", data={'user': None})
>>> public_signal.generate_signal_metadata()
{'id': UUID('b6af26cc-ee39-11eb-8988-0242ac19000b'), 'event_type': 'org.openedx.learning.session.login.completed.v1', 'minorversion': 0, 'time': datetime.datetime(2021, 7, 26, 17, 48, 41, 41263), 'source': 'openedx/lms/web', 'sourcehost': 'lms.devstack.edx', 'sourcelib': (0, 1, 3)}
```
**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
