### PR TITLE
feat: preliminary signal definition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+Added
+_____
+* Preliminary Open edX events definitions.
+
 [0.3.0] - 2021-08-18
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Added

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -7,3 +7,113 @@ conventions specified in docs/decisions/0002-events-naming-and-versioning.rst
 They also must comply with the payload definition specified in
 docs/decisions/0003-events-payload.rst
 """
+
+from openedx_events.learning.data import CertificateData, CohortData, CourseEnrollmentData, UserData
+from openedx_events.tooling import OpenEdxPublicSignal
+
+# .. event_type: org.openedx.learning.student.registration.completed.v1
+# .. event_name: STUDENT_REGISTRATION_COMPLETED
+# .. event_description: emitted when the user registration process in the LMS is completed.
+# .. event_data: UserData
+STUDENT_REGISTRATION_COMPLETED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.student.registration.completed.v1",
+    data={
+        "user": UserData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.auth.session.login.completed.v1
+# .. event_name: SESSION_LOGIN_COMPLETED
+# .. event_description: emitted when the user's login process in the LMS is completed.
+# .. event_data: UserData
+SESSION_LOGIN_COMPLETED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.auth.session.login.completed.v1",
+    data={
+        "user": UserData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.course.enrollment.created.v1
+# .. event_name: COURSE_ENROLLMENT_CREATED
+# .. event_description: emitted when the user's enrollment process is completed.
+# .. event_data: CourseEnrollmentData
+COURSE_ENROLLMENT_CREATED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.course.enrollment.created.v1",
+    data={
+        "enrollment": CourseEnrollmentData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.course.enrollment.changed.v1
+# .. event_name: COURSE_ENROLLMENT_CHANGED
+# .. event_description: emitted when the user's enrollment update process is completed.
+# .. event_data: CourseEnrollmentData
+COURSE_ENROLLMENT_CHANGED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.course.enrollment.changed.v1",
+    data={
+        "enrollment": CourseEnrollmentData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.course.unenrollment.completed.v1
+# .. event_name: COURSE_ENROLLMENT_CHANGED
+# .. event_description: emitted when the user's unenrollment process is completed.
+# .. event_data: CourseEnrollmentData
+COURSE_UNENROLLMENT_COMPLETED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.course.unenrollment.completed.v1",
+    data={
+        "enrollment": CourseEnrollmentData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.certificate.created.v1
+# .. event_name: CERTIFICATE_CREATED
+# .. event_description: emitted when the user's certificate creation process is completed.
+# .. event_data: CertificateData
+CERTIFICATE_CREATED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.certificate.created.v1",
+    data={
+        "certificate": CertificateData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.certificate.changed.v1
+# .. event_name: CERTIFICATE_CHANGED
+# .. event_description: emitted when the user's certificate update process is completed.
+# .. event_data: CertificateData
+CERTIFICATE_CHANGED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.certificate.changed.v1",
+    data={
+        "certificate": CertificateData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.certificate.revoked.v1
+# .. event_name: CERTIFICATE_REVOKED
+# .. event_description: emitted when the user's certificate annulation process is completed.
+# .. event_data: CertificateData
+CERTIFICATE_REVOKED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.certificate.revoked.v1",
+    data={
+        "certificate": CertificateData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.cohort_membership.changed.v1
+# .. event_name: COHORT_MEMBERSHIP_CHANGED
+# .. event_description: emitted when the user's cohort update is completed.
+# .. event_data: CohortData
+COHORT_MEMBERSHIP_CHANGED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.cohort_membership.changed.v1",
+    data={
+        "cohort": CohortData,
+    }
+)


### PR DESCRIPTION
**Description:** 
This PR adds the first 8 definitions of the Open edX events, they will be used in the Open edX platform.

**JIRA:** Link to JIRA ticket

**Dependencies:**\
Depends on #8 (merged)

**Testing instructions:**

With the event `STUDENT_REGISTRATION_COMPLETED`:
In your Open edX devstack
1. Go to lms shell `make lms-shell`
2. Install openedx-events specifying the events definition branch:
 `pip install git+https://github.com/eduNEXT/openedx-events.git@MJG/events_definition#egg=events_definition` 
3. Change the Open edX platform branch to [eduNEXT:MJG/1st_batch_openedx_events](https://github.com/edx/edx-platform/pull/28266)
4. Connect your custom receiver to the signal as follows:

```
from openedx_events.learning.signals import STUDENT_REGISTRATION_COMPLETED

@receiver(STUDENT_REGISTRATION_COMPLETED)
def callback(**kwargs):
....
```
We'll add soon an example using our plugin openedx-basic-hooks!

**Reviewers:**
- [ ] @felipemontoya 
- [ ] @andrey-canon 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
None for now