### PR TITLE
test: remove max-doc-length from tox.ini file due to community recommendation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ ignore=D001
 [pycodestyle]
 exclude = .git,.tox
 max-line-length = 120
-max-doc-length = 79
+max-doc-length = 120
 
 [pydocstyle]
 ; D101 = Missing docstring in public class


### PR DESCRIPTION
This PR adds support for 120 max doc lines. Suggestion taken from: https://github.com/eduNEXT/openedx-events/pull/18#discussion_r675183610
