### PR TITLE
refactor: remove unnecessary instantiation check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+Changed
+_______
+* Remove unnecessary InstantiationError exception.
 
 [0.5.1] - 2021-08-26
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/openedx_events/tests/test_tooling.py
+++ b/openedx_events/tests/test_tooling.py
@@ -9,7 +9,7 @@ import attr
 import ddt
 from django.test import TestCase, override_settings
 
-from openedx_events.exceptions import InstantiationError, SenderValidationError
+from openedx_events.exceptions import SenderValidationError
 from openedx_events.tooling import OpenEdxPublicSignal
 
 
@@ -66,28 +66,6 @@ class OpenEdxPublicSignalTest(TestCase):
         metadata = self.public_signal.generate_signal_metadata()
 
         self.assertDictContainsSubset(expected_metadata, attr.asdict(metadata))
-
-    @ddt.data(
-        ("", {"user": Mock()}, "event_type"),
-        ("org.openedx.learning.session.login.completed.v1", None, "data"),
-    )
-    @ddt.unpack
-    def test_event_instantiation_exception(
-        self, event_type, event_data, missing_argument
-    ):
-        """
-        This method tests when an event is instantiated without event_type or
-        event data.
-
-        Expected behavior:
-            An InstantiationError exception is raised.
-        """
-        exception_message = "InstantiationError {event_type}: Missing required argument '{missing_argument}'".format(
-            event_type=event_type, missing_argument=missing_argument
-        )
-
-        with self.assertRaisesMessage(InstantiationError, exception_message):
-            OpenEdxPublicSignal(event_type=event_type, data=event_data)
 
     @patch("openedx_events.tooling.OpenEdxPublicSignal.generate_signal_metadata")
     @patch("openedx_events.tooling.Signal.send")

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -6,7 +6,7 @@ import warnings
 from django.dispatch import Signal
 
 from openedx_events.data import EventsMetadata
-from openedx_events.exceptions import InstantiationError, SenderValidationError
+from openedx_events.exceptions import SenderValidationError
 
 
 class OpenEdxPublicSignal(Signal):
@@ -26,14 +26,6 @@ class OpenEdxPublicSignal(Signal):
             data (dict): attributes passed to the event.
             minor_version (int): version of the event type.
         """
-        if not event_type:
-            raise InstantiationError(
-                message="Missing required argument 'event_type'"
-            )
-        if not data:
-            raise InstantiationError(
-                event_type=event_type, message="Missing required argument 'data'"
-            )
         self.init_data = data
         self.event_type = event_type
         self.minor_version = minor_version


### PR DESCRIPTION
**Description:** 
The code block was necessary when we used defaults for event_data and data, but after changing them to positional args is useless.