### PR TITLE
fix: remove assignment to metadata object

### DIFF
--- a/openedx_events/tests/test_tooling.py
+++ b/openedx_events/tests/test_tooling.py
@@ -98,10 +98,7 @@ class OpenEdxPublicSignalTest(TestCase):
         Expected behavior:
             The event is sent as a django signal.
         """
-        expected_metadata = {
-            "some_data": "data",
-            "raise_exception": True,
-        }
+        expected_metadata = Mock(some_data="some_data")
         fake_metadata.return_value = expected_metadata
 
         self.public_signal.send_event(user=self.user_mock)
@@ -121,10 +118,7 @@ class OpenEdxPublicSignalTest(TestCase):
         Expected behavior:
             The event is sent as a django signal.
         """
-        expected_metadata = {
-            "some_data": "data",
-            "raise_exception": True,
-        }
+        expected_metadata = Mock(some_data="some_data")
         fake_metadata.return_value = expected_metadata
 
         self.public_signal.send_event(user=self.user_mock, send_robust=True)

--- a/openedx_events/tooling.py
+++ b/openedx_events/tooling.py
@@ -129,7 +129,6 @@ class OpenEdxPublicSignal(Signal):
         validate_sender()
 
         kwargs["metadata"] = self.generate_signal_metadata()
-        kwargs["metadata"]["raise_exception"] = not send_robust
 
         if send_robust:
             return super().send_robust(sender=None, **kwargs)


### PR DESCRIPTION
**Description:** 

This PR fixes the following error:

![image](https://user-images.githubusercontent.com/64440265/129991030-8a0ccacd-f924-45bf-9879-5b955598756d.png)

The implementation was correct when metadata was just a dictionary