### PR TITLE
test: add signal isolation class and methods

### DIFF
--- a/openedx_events/tests/__init__.py
+++ b/openedx_events/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test package for openedx-events implementations.
+"""

--- a/openedx_events/tests/test_tooling.py
+++ b/openedx_events/tests/test_tooling.py
@@ -185,3 +185,18 @@ class OpenEdxPublicSignalTest(TestCase):
 
         with self.assertWarns(Warning, msg=message):
             self.public_signal.send_robust(sender=Mock())
+
+    @patch("openedx_events.tooling.Signal.send")
+    def test_send_event_disabled(self, send_mock):
+        """
+        This method tests sending an event that has been disabled.
+
+        Expected behavior:
+            The Django Signal associated to the event is not sent.
+        """
+        self.public_signal.disable()
+
+        result = self.public_signal.send_event(sender=Mock())
+
+        send_mock.assert_not_called()
+        self.assertListEqual([], result)

--- a/openedx_events/tests/utils.py
+++ b/openedx_events/tests/utils.py
@@ -1,0 +1,78 @@
+"""
+Utils used by Open edX events.
+"""
+from django.test import TestCase
+
+from openedx_events.tooling import OpenEdxPublicSignal
+
+
+class EventsIsolationMixin:
+    """
+    A mixin to be used by TestCases that want to isolate their use of Open edX Events.
+    """
+
+    @classmethod
+    def disable_all_events(cls):
+        """
+        Disable all events Open edX Events from all subdomains.
+        """
+        for event in OpenEdxPublicSignal.all_events():
+            event.disable()
+
+    @classmethod
+    def enable_all_events(cls):
+        """
+        Enable all events Open edX Events from all subdomains.
+        """
+        for event in OpenEdxPublicSignal.all_events():
+            event.enable()
+
+    @classmethod
+    def enable_events_by_type(cls, *event_types):
+        """
+        Enable specific Open edX Events given their type.
+
+        Arguments:
+            event_types (list of `str`): types of events to enable.
+        """
+        for event_type in event_types:
+            try:
+                event = OpenEdxPublicSignal.get_signal_by_type(event_type)
+            except KeyError:
+                all_event_types = sorted(s.event_type for s in OpenEdxPublicSignal.all_events())
+                err_msg = (
+                    "You tried to enable event '{}', but I don't recognize that "
+                    "signal type. Did you mean one of these?: {}"
+                )
+                raise ValueError(err_msg.format(event_type, all_event_types))  # pylint: disable=raise-missing-from
+            event.enable()
+
+
+class OpenEdxEventsTestCase(EventsIsolationMixin, TestCase):
+    """
+    A mixin to be used by TestCases that want to isolate their use of Open edX Events.
+
+    Example usage:
+
+        class MyTestCase(OpenEdxEventsTestCase):
+
+            ENABLED_OPENEDX_EVENTS = ['org.openedx.learning.student.registration.completed.v1']
+    """
+
+    ENABLED_OPENEDX_EVENTS = []
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Start events isolation for class.
+        """
+        super().setUpClass()
+        cls().start_events_isolation()
+
+    @classmethod
+    def start_events_isolation(cls):
+        """
+        Start Open edX Events isolation and then enable events by type.
+        """
+        cls().disable_all_events()
+        cls().enable_events_by_type(*cls.ENABLED_OPENEDX_EVENTS)


### PR DESCRIPTION
**Description:** 
This PR adds classes and methods that allow developers to enable/disable events during testing. This implementation is a result of [this](https://github.com/edx/edx-platform/pull/28266#discussion_r692455863) discussion

**Testing instructions:**

1. `make lms-shell`
2. pip install git+https://github.com/eduNEXT/openedx-events@MJG/isolate_signal_sending#egg=openedx-events==0.5.0_alpha
3. Go to [openedx/core/djangoapps/user_api/tests/test_views.py L31](https://github.com/edx/edx-platform/blob/572965b7427c4c122abc78b04a624ed6a13e9742/openedx/core/djangoapps/user_api/tests/test_views.py#L31) 
4. In `UserAPITestCase` add the mixin `OpenEdxEventsTestCase`
5. Execute tests, for example: `pytest openedx/core/djangoapps/user_authn/views/tests/test_register.py::RegistrationValidationViewTests`
6. Manually check that the signal is not sent

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
