### PR TITLE
feat: change send_robust to default method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,9 +13,15 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+Added
+_____
+* Add custom formatting class for events responses.
+* Add a way to use send method instead of send_robust while testing.
+
 Changed
 _______
 * Remove unnecessary InstantiationError exception.
+* Default is send_robust instead of send unless specified otherwise.
 
 [0.5.1] - 2021-08-26
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/openedx_events/tests/test_tooling.py
+++ b/openedx_events/tests/test_tooling.py
@@ -71,13 +71,14 @@ class OpenEdxPublicSignalTest(TestCase):
     @patch("openedx_events.tooling.Signal.send")
     def test_send_event_successfully(self, send_mock, fake_metadata):
         """
-        This method tests the process of sending an event.
+        This method tests the process of sending an event that's allow to fail.
 
         Expected behavior:
-            The event is sent as a django signal.
+            The event is sent as a django signal with send method.
         """
         expected_metadata = Mock(some_data="some_data")
         fake_metadata.return_value = expected_metadata
+        self.public_signal.allow_send_event_failure()
 
         self.public_signal.send_event(user=self.user_mock)
 
@@ -91,15 +92,16 @@ class OpenEdxPublicSignalTest(TestCase):
     @patch("openedx_events.tooling.Signal.send_robust")
     def test_send_robust_event_successfully(self, send_robust_mock, fake_metadata):
         """
-        This method tests the process of sending an event.
+        This method tests the process of sending an event that won't crash.
 
         Expected behavior:
-            The event is sent as a django signal.
+            The event is sent as a django signal with send_robust method.
         """
         expected_metadata = Mock(some_data="some_data")
         fake_metadata.return_value = expected_metadata
+        send_robust_mock.return_value.__name__ = "func_name"
 
-        self.public_signal.send_event(user=self.user_mock, send_robust=True)
+        self.public_signal.send_event(user=self.user_mock)
 
         send_robust_mock.assert_called_once_with(
             sender=None,

--- a/openedx_events/tests/utils.py
+++ b/openedx_events/tests/utils.py
@@ -45,6 +45,29 @@ class EventsIsolationMixin:
                 raise ValueError(err_msg.format(event_type, all_event_types))  # pylint: disable=raise-missing-from
             event.enable()
 
+    @classmethod
+    def allow_send_events_failure(cls, *event_types):
+        """
+        Allow that send_event method fails for the specified event.
+
+        This method determines which `send` method to use, send or send_robust.
+        The first, raises receivers exceptions while the latter catches them.
+
+        Arguments:
+            event_types (list of `str`): types of events to enable.
+        """
+        for event_type in event_types:
+            try:
+                event = OpenEdxPublicSignal.get_signal_by_type(event_type)
+            except KeyError:
+                all_event_types = sorted(s.event_type for s in OpenEdxPublicSignal.all_events())
+                err_msg = (
+                    "You tried to enable event '{}', but I don't recognize that "
+                    "signal type. Did you mean one of these?: {}"
+                )
+                raise ValueError(err_msg.format(event_type, all_event_types))  # pylint: disable=raise-missing-from
+            event.allow_send_event_failure()
+
 
 class OpenEdxEventsTestMixin(EventsIsolationMixin):
     """
@@ -76,3 +99,4 @@ class OpenEdxEventsTestMixin(EventsIsolationMixin):
         """
         cls().disable_all_events()
         cls().enable_events_by_type(*cls.ENABLED_OPENEDX_EVENTS)
+        cls().allow_send_events_failure(*cls.ENABLED_OPENEDX_EVENTS)

--- a/openedx_events/utils.py
+++ b/openedx_events/utils.py
@@ -1,0 +1,86 @@
+"""
+Utilities for Open edX events usage.
+"""
+import collections
+import traceback
+from pprint import PrettyPrinter
+
+
+class ResponsePrettyPrinter(PrettyPrinter):
+    """
+    Custom printer for Open edX Events responses.
+
+    This class pretty-prints the response of common Django Signals.
+    """
+
+    def _format(self, obj, stream, indent, allowance, context, level):  # pylint: disable=arguments-renamed
+        """
+        Override format method exposing more information about functions/exceptions.
+
+        When formatting a function this method will return the function path.
+        When formatting an exception this method will return the stack trace of the
+        exception.
+        With other objects has the same behavior.
+        """
+        if isinstance(obj, Exception):
+            exc_type, exc_value, exc_traceback = type(obj), obj, obj.__traceback__
+            exc_traceback_formatted = traceback.format_exception(
+                exc_type, exc_value, exc_traceback
+            )
+            obj = "".join(exc_traceback_formatted)
+        if isinstance(obj, collections.Callable):
+            obj = "{func_module}.{func_name}".format(
+                func_module=obj.__module__,
+                func_name=obj.__name__,
+            )
+        return super()._format(obj, stream, indent, allowance, context, level)
+
+
+def format_responses(obj, indent=1, width=80, depth=None, *, compact=False, sort_dicts=True):
+    """
+    Format a Django Signal response object into a pretty-printed representation.
+
+    Example usage:
+
+        log.info(
+                "Responses of the Open edX Event <%s>: %s",
+                self.event_type,
+                format_responses(responses, depth=2),
+            )
+        Will result in:
+        [
+            (
+                'openedx_basic_hooks.receivers.login_receiver',
+                'Traceback (most recent call last):'
+                '  File '
+                '"/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/dispatch/dispatcher.py", '
+                'line 207, in send_robust'
+                '    response = receiver(signal=self, sender=sender, **named)'
+                '  File "/edx/src/openedx-basic-hooks/openedx_basic_hooks/receivers.py", '
+                'line 18, in login_receiver'
+                '    m = 1/0'
+                'ZeroDivisionError: division by zero'
+            )
+        ]
+
+    Arguments:
+        obj (tuple): response object to be formatted.
+        indent (int): specifies the amount of indentation added to each recursive level.
+        width (int): desired output width.
+        depth (int): number of levels to represent.
+        compact (bool): when true, will format as many items as will fit within the width
+        on each output line.
+        sort_dicts (bool): dictionaries will be formatted with their keys sorted.
+
+    Same as in https://docs.python.org/3/library/pprint.html#pprint.PrettyPrinter
+
+    Returns:
+        (str) string representation of Open edX events responses.
+    """
+    return ResponsePrettyPrinter(
+        indent=indent,
+        width=width,
+        depth=depth,
+        compact=compact,
+        sort_dicts=sort_dicts,
+    ).pformat(obj)


### PR DESCRIPTION
**Description:** 
This PR changes which send method to use when sending an event, so they don't fail during runtime. Instead, they will be allowed to fail in a testing/dev environment.

**Testing instructions:**

Test new default:
One of the ways to test the new default besides a production environment is in a test environment where no events are turned on. Meaning, the test class has the mixin `OpenEdxEventsTestMixin` with `ENABLED_OPENEDX_EVENTS = []`. For example: 
https://github.com/edx/edx-platform/blob/master/common/djangoapps/student/tests/test_enrollment.py#L34

1. In a testing environment, connect a handler to one of the Open edX Events available. For example, from a plugin you could do:
```
                    {
                        "receiver_func_name": "enrollment_receiver",
                        "signal_path": "openedx_events.learning.signals.COURSE_ENROLLMENT_CREATED",
                    },
```
Where:
```
def enrollment_receiver(*args, **kwargs):
    """
    Login Open edX Event receiver.
    """
    raise Exception
```
2. Run one of the tests from test_enrollment, it could be: test_unenroll. 
`pytest common/djangoapps/student/tests/test_enrollment.py::EnrollmentTest::test_unenroll`

When the test case executes, it calls CourseEnrollment.enroll, this will fire the signal that will be received by enrollment_receiver. Given that the default is send_robust, the test shouldn't fail, just logs the result:
![event-response-log](https://user-images.githubusercontent.com/64440265/132700327-80b84660-44f1-43ca-8106-20c19deb2345.png)

If we wanted to test that the receiver fails, then add to `ENABLED_OPENEDX_EVENTS = []` the name of the event `"org.openedx.learning.course.enrollment.created.v1"`.

Test failure in dev environment:
1. In a development environment, connect a handler to one of the Open edX Events available. For example, from a plugin you could do:
```
                    {
                        "receiver_func_name": "enrollment_receiver",
                        "signal_path": "openedx_events.learning.signals.COURSE_ENROLLMENT_CREATED",
                    },
```
Where:
```
def enrollment_receiver(*args, **kwargs):
    """
    Login Open edX Event receiver.
    """
    raise Exception
```
2. Enroll in a course, the exception must appear in the LMS.

**Reviewers:**

- [x] @felipemontoya 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
None for now.
