### PR TITLE
feat: Discussion event extraction, in openedx-event library

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Unreleased
 
 Added
 -----
+* Added COURSE_DISCUSSIONS_CHANGED for discussion event
 * Added data definition for enterprise/LicenseLifecycle
 * Added LicenseCreated signal definition
 

--- a/openedx_events/learning/data.py
+++ b/openedx_events/learning/data.py
@@ -5,9 +5,10 @@ These attributes follow the form of attr objects specified in OEP-49 data
 pattern.
 """
 from datetime import datetime
+from typing import List
 
 import attr
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, UsageKey
 
 
 @attr.s(frozen=True)
@@ -135,3 +136,49 @@ class CohortData:
     user = attr.ib(type=UserData)
     course = attr.ib(type=CourseData)
     name = attr.ib(type=str)
+
+
+@attr.s(frozen=True)
+class DiscussionTopicContext:
+    """
+    Attributes defined for Open edX Discussion Topic Context object.
+
+    Context for linking the external id for a discussion topic to its associated usage key.
+
+    Arguments:
+        title (str): is cached to improve the performance.
+        usage_key (str): usage key.
+        group_id(int): can be used for providers that don't internally support cohorting.
+        external_id(str): store the commentable id.
+    """
+
+    title = attr.ib(type=str)
+    usage_key = attr.ib(type=UsageKey, default=None)
+    group_id = attr.ib(type=int, default=None)
+    external_id = attr.ib(type=str, default=None)
+
+
+@attr.s(frozen=True)
+class CourseDiscussionConfigurationData:
+    """
+    Attributes defined for Open edX Course Discussion Configuration Data object.
+
+    Contains all the metadata needed to configure discussions for a course.
+
+    Arguments:
+        course_key(str): information about the course
+        provider_type(str): provider type
+        enable_in_context(bool): enable in context
+        enable_graded_units(bool): enable grade units
+        plugin_configuration(dict): plugin configuration
+        contexts(List): field contains all the contexts for which discussion
+        is to be enabled.
+    """
+
+    course_key = attr.ib(type=CourseKey)
+    provider_type = attr.ib(type=str)
+    enable_in_context = attr.ib(type=bool, default=True)
+    enable_graded_units = attr.ib(type=bool, default=False)
+    unit_level_visibility = attr.ib(type=bool, default=False)
+    plugin_configuration = attr.ib(type=dict, default={})
+    contexts = attr.ib(type=List[DiscussionTopicContext], factory=list)

--- a/openedx_events/learning/signals.py
+++ b/openedx_events/learning/signals.py
@@ -8,7 +8,13 @@ They also must comply with the payload definition specified in
 docs/decisions/0003-events-payload.rst
 """
 
-from openedx_events.learning.data import CertificateData, CohortData, CourseEnrollmentData, UserData
+from openedx_events.learning.data import (
+    CertificateData,
+    CohortData,
+    CourseDiscussionConfigurationData,
+    CourseEnrollmentData,
+    UserData,
+)
 from openedx_events.tooling import OpenEdxPublicSignal
 
 # .. event_type: org.openedx.learning.student.registration.completed.v1
@@ -115,5 +121,17 @@ COHORT_MEMBERSHIP_CHANGED = OpenEdxPublicSignal(
     event_type="org.openedx.learning.cohort_membership.changed.v1",
     data={
         "cohort": CohortData,
+    }
+)
+
+
+# .. event_type: org.openedx.learning.discussions.configuration.changed.v1
+# .. event_name: COURSE_DISCUSSIONS_CHANGED
+# .. event_description: emitted when the configuration for a course's discussions changes in the course
+# .. event_data: CourseDiscussionConfigurationData
+COURSE_DISCUSSIONS_CHANGED = OpenEdxPublicSignal(
+    event_type="org.openedx.learning.discussions.configuration.changed.v1",
+    data={
+        "configuration": CourseDiscussionConfigurationData
     }
 )


### PR DESCRIPTION
**Description:** 
This PR extract the definition of `COURSE_DISCUSSIONS_CHANGED` event and his `attr` data from `edx-platform` to `openedx-events` library.

**Testing instructions:**
1. In studio, modified the content of a course in a unit and publish changes
2. You should see new DiscussionTopicLink objects, one for each general topic and one for each unit.
3. In studio logs you can see `log.info` for "Updating existing discussion topic links for" or "Creating new discussion topic links for"
4. In django admin you can see `DiscussionsConfiguration` in change discussions configuration 

**Support information:**
PRs merge in `openedx/edx-platform`
- https://github.com/openedx/edx-platform/pull/29082
- https://github.com/openedx/edx-platform/pull/28749

**Merge checklist:**
- [x] Reviewers approved
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
None for now.
